### PR TITLE
Ensure only valid objects are presented via the ObjectManager player view

### DIFF
--- a/src/Orion.GlobalOffensive/Orion.GlobalOffensive/ObjectManager.cs
+++ b/src/Orion.GlobalOffensive/Orion.GlobalOffensive/ObjectManager.cs
@@ -40,9 +40,9 @@ namespace Orion.GlobalOffensive
 		}
 
 		/// <summary>
-		///     Gets the current objects in the game world.
+		///     Gets the current valid objects in the game world.
 		/// </summary>
-		public IReadOnlyList<BaseEntity> Players => _players;
+		public IReadOnlyList<BaseEntity> Players => _players.Where(p => p.IsValid).ToList();
 
 		internal LocalPlayer LocalPlayer { get; private set; }
 


### PR DESCRIPTION
Addresses #6 by only exposing valid objects via `ObjectManager.Players`.
